### PR TITLE
use RW non-aware mutex to reduce cacheline footprint

### DIFF
--- a/skinny/control.go
+++ b/skinny/control.go
@@ -8,8 +8,8 @@ import (
 
 // Status exposes internal state information of an instance
 func (in *Instance) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusResponse, error) {
-	in.mu.RLock()
-	defer in.mu.RUnlock()
+	in.mu.Lock()
+	defer in.mu.Unlock()
 
 	status := pb.StatusResponse{
 		Name:      in.name,

--- a/skinny/skinny.go
+++ b/skinny/skinny.go
@@ -12,7 +12,7 @@ import (
 
 // Instance represents a skinny distributed lock management service instance
 type Instance struct {
-	mu sync.RWMutex
+	mu sync.Mutex
 	// begin protected fields
 	name      string
 	increment uint64


### PR DESCRIPTION
`sync.RWMutex` has a larger memory footprint than `sync.Mutex` which may or may not align with a processors cache line. Furthermore, each call to `RLock()` requires writing to the memory which invalidates the cache line on all other cores/processors. It is therefore advised to not use `RWMutex` unless the ratio of read over writes is heavily on the reader side. Here, it isn't really, unless the instances are being observed at a ridiculous high frequency.